### PR TITLE
Adds a .packit file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .bin
 rust-cargo_*
+build

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,6 @@ api = "0.4"
 [buildpack]
   id = "paketo-community/cargo-install"
   name = "Rust Cargo Build Pack"
-  version = "0.0.3"
   homepage = "https://github.com/paketo-community/cargo-install"
 
 [[stacks]]
@@ -16,5 +15,5 @@ api = "0.4"
   id = "io.paketo.stacks.tiny"
 
 [metadata]
-  include_files = ["bin/build", "bin/detect", "buildpack.toml"]
-  pre_package = "./scripts/build.sh"
+  include-files = ["bin/build", "bin/detect", "buildpack.toml"]
+  pre-package = "./scripts/build.sh"


### PR DESCRIPTION
- This file indicates to the automation which packager should be used.
This will mean that the buildpack will now be built with jam and receive
the proper formatting. Previously the version inside of buildpack.toml
was not being overwritten.