### PR TITLE
Add VersionSource information so that the output when selecting a rust version looks nicer

### DIFF
--- a/cargo/detect.go
+++ b/cargo/detect.go
@@ -12,6 +12,12 @@ import (
 // PlanDependencyRustCargo is the name of the plan
 const PlanDependencyRustCargo = "rust-cargo"
 
+// BuildPlanMetadata defines the information stored in the build plan
+type BuildPlanMetadata struct {
+	VersionSource string `toml:"version-source"`
+	Version       string `toml:"version"`
+}
+
 // Detect if the Rust binaries should be delivered
 func Detect() packit.DetectFunc {
 	return func(context packit.DetectContext) (packit.DetectResult, error) {
@@ -38,7 +44,13 @@ func Detect() packit.DetectFunc {
 				},
 				Requires: []packit.BuildPlanRequirement{
 					{Name: PlanDependencyRustCargo},
-					{Name: "rust"},
+					{
+						Name: "rust",
+						Metadata: BuildPlanMetadata{
+							Version:       "",
+							VersionSource: "CARGO",
+						},
+					},
 				},
 			},
 		}, nil

--- a/cargo/detect_test.go
+++ b/cargo/detect_test.go
@@ -53,7 +53,13 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					},
 					Requires: []packit.BuildPlanRequirement{
 						{Name: cargo.PlanDependencyRustCargo},
-						{Name: "rust"},
+						{
+							Name: "rust",
+							Metadata: cargo.BuildPlanMetadata{
+								Version:       "",
+								VersionSource: "CARGO",
+							},
+						},
 					},
 				},
 			}))


### PR DESCRIPTION
This isn't actually an improvement for the cargo-install CNB, but it makes the output in the rust-dist CNB look nicer.

Prior to this change:

```
Rust Distribution Buildpack 0.0.10
  Resolving Rust version
    Candidate version sources (in priority order):
      <unknown> -> ""
```

"unknown" is a little scary. With this change:

```
Rust Distribution Buildpack 0.0.10
  Resolving Rust version
    Candidate version sources (in priority order):
      CARGO -> ""
```

Cargo itself doesn't seem to lock in a Rust version, at least as far as I know. I put CARGO because this happens when the cargo-install CNB's detect script indicates that it requires "rust". If we include "CARGO" as the version source, then the output of the rust-dist CNB is a little nicer.