### PR TITLE
Update buildpack.toml & improve error message

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,9 +1,15 @@
-api = "0.4"
+api = "0.5"
 
 [buildpack]
-  homepage = "https://github.com/paketo-community/cargo-install"
   id = "paketo-community/cargo-install"
   name = "Rust Cargo Build Pack"
+  homepage = "https://github.com/paketo-community/cargo-install"
+  description = "A Cloud Native Buildpack that builds Cargo-based Rust applications from source"
+  keywords    = ["cargo", "rust", "build-system"]
+
+[[buildpack.licenses]]
+  type = "Apache-2.0"
+  uri  = "https://github.com/paketo-community/cargo-install/blob/main/LICENSE"
 
 [metadata]
   include-files = ["bin/run", "bin/build", "bin/detect", "buildpack.toml"]
@@ -13,7 +19,7 @@ api = "0.4"
   id = "io.buildpacks.stacks.bionic"
 
 [[stacks]]
-  id = "org.cloudfoundry.stacks.cflinuxfs3"
+  id = "io.paketo.stacks.tiny"
 
 [[stacks]]
-  id = "io.paketo.stacks.tiny"
+  id = "*"

--- a/cargo/cli_runner.go
+++ b/cargo/cli_runner.go
@@ -97,7 +97,7 @@ func (c CLIRunner) WorkspaceMembers(srcDir string, workLayer packit.Layer, destL
 		Args:   []string{"metadata", "--format-version=1", "--no-deps"},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("build failed: %w", err)
+		return nil, fmt.Errorf("build failed: %s\n%w", &stdout, err)
 	}
 
 	var m metadata


### PR DESCRIPTION
1. Bump buildpack API to 0.5
2. Add description & keywords metadata
3. Add buildpack license info
4. Remove cflinuxfs3 stack
5. Add wildcard stack since this buildpack should work with any stack
6. Includes STDOUT when running `cargo metadata` which makes it easier to troubleshoot if something goes wrong.