### PR TITLE
Fix detect fails with error #91

### DIFF
--- a/cargo/detect.go
+++ b/cargo/detect.go
@@ -35,7 +35,7 @@ func Detect() packit.DetectFunc {
 
 		if !cargoTomlFound || !cargoLockFound {
 			//lint:ignore ST1005 Reads nicer when displayed to end user with leading capital letter
-			return packit.DetectResult{}, fmt.Errorf("Missing [Cargo.toml: %v, Cargo.lock: %v], both required", !cargoTomlFound, !cargoLockFound)
+			return packit.DetectResult{}, packit.Fail.WithMessage(fmt.Sprintf("Missing [Cargo.toml: %v, Cargo.lock: %v], both required", !cargoTomlFound, !cargoLockFound))
 		}
 
 		return packit.DetectResult{


### PR DESCRIPTION
Wrap the error in packit.Fail during the detection phase to mute the
error when chaining multiple buildpacks.